### PR TITLE
Parsing (part 3)

### DIFF
--- a/src/main/scala/com/github/sophiecollard/hangeul4s/model/hangeul/HangeulText.scala
+++ b/src/main/scala/com/github/sophiecollard/hangeul4s/model/hangeul/HangeulText.scala
@@ -17,7 +17,7 @@ object HangeulText {
   def fromElements(e: HangeulTextElement, es: HangeulTextElement*): HangeulText =
     HangeulText(NonEmptyVector(e, es.toVector))
 
-  private val splittingRegex: Regex = "([\uAC00-\uD7AF]+)|([^\uAC00-\uD7AF]+)".r
+  private val splittingRegex: Regex = "([\uAC00-\uD7AF]+)|([^\\s\uAC00-\uD7AF]+)".r
 
   val parser: AccumulativeParser[HangeulText] =
     AccumulativeParser.instance[HangeulText] { input =>

--- a/src/test/scala/com/github/sophiecollard/hangeul4s/model/hangeul/HangeulTextSpec.scala
+++ b/src/test/scala/com/github/sophiecollard/hangeul4s/model/hangeul/HangeulTextSpec.scala
@@ -18,40 +18,36 @@ class HangeulTextSpec extends Specification {
           TwoLetter(Initial.ㅅ, Medial.ㅣ),
           ThreeLetter(Initial.ㅊ, Medial.ㅓ, Final.ㅇ)
         ),
-        HangeulTextElement.NotCaptured.unvalidatedFrom(" "),
         HangeulTextElement.Captured.fromSyllabicBlocks(
           TwoLetter(Initial.ㅅ, Medial.ㅗ),
           TwoLetter(Initial.ㅈ, Medial.ㅐ),
           TwoLetter(Initial.ㅈ, Medial.ㅣ),
           ThreeLetter(Initial.ㄴ, Medial.ㅡ, Final.ㄴ)
         ),
-        HangeulTextElement.NotCaptured.unvalidatedFrom(" "),
         HangeulTextElement.Captured.fromSyllabicBlocks(
           ThreeLetter(Initial.ㅈ, Medial.ㅜ, Final.ㅇ),
           TwoLetter(Initial.ㄱ, Medial.ㅜ),
           TwoLetter(Initial.ㅇ, Medial.ㅣ),
           TwoLetter(Initial.ㅁ, Medial.ㅕ)
         ),
-        HangeulTextElement.NotCaptured.unvalidatedFrom(", 25"),
+        HangeulTextElement.NotCaptured.unvalidatedFrom(","),
+        HangeulTextElement.NotCaptured.unvalidatedFrom("25"),
         HangeulTextElement.Captured.fromSyllabicBlocks(
           TwoLetter(Initial.ㄱ, Medial.ㅐ),
           TwoLetter(Initial.ㅇ, Medial.ㅢ)
         ),
-        HangeulTextElement.NotCaptured.unvalidatedFrom(" "),
         HangeulTextElement.Captured.fromSyllabicBlocks(
           TwoLetter(Initial.ㅈ, Medial.ㅏ),
           TwoLetter(Initial.ㅊ, Medial.ㅣ),
           TwoLetter(Initial.ㄱ, Medial.ㅜ),
           TwoLetter(Initial.ㄹ, Medial.ㅗ)
         ),
-        HangeulTextElement.NotCaptured.unvalidatedFrom(" "),
         HangeulTextElement.Captured.fromSyllabicBlocks(
           TwoLetter(Initial.ㅇ, Medial.ㅣ),
           TwoLetter(Initial.ㄹ, Medial.ㅜ),
           TwoLetter(Initial.ㅇ, Medial.ㅓ),
           TwoLetter(Initial.ㅈ, Medial.ㅕ)
         ),
-        HangeulTextElement.NotCaptured.unvalidatedFrom(" "),
         HangeulTextElement.Captured.fromSyllabicBlocks(
           ThreeLetter(Initial.ㅇ, Medial.ㅣ, Final.ㅆ),
           TwoLetter(Initial.ㄷ, Medial.ㅏ)


### PR DESCRIPTION
Todo
- [x] Don't capture whitespace when parsing `HangeulTextElement`